### PR TITLE
Fix to address SGE PATH environment variable problem with newer versi…

### DIFF
--- a/ample/ensembler/__init__.py
+++ b/ample/ensembler/__init__.py
@@ -53,6 +53,7 @@ def cluster_script(amoptd, python_path="ccp4-python"):
     script_path = os.path.join(work_dir, "submit_ensemble.sh")
     with open(script_path, "w") as job_script:
         job_script.write(ample_util.SCRIPT_HEADER + os.linesep)
+        job_script.write("export PATH=${PATH}:${SGE_O_PATH}" + os.linesep) #Fix to address new SGE version PATH issue
         job_script.write("export CCP4_SCR=${TMPDIR}" + os.linesep) #Added by Ronan after issues on CCP4online server
         job_script.write("ccp4-python -m ample.ensembler -restart_pkl {0}".format(amoptd['results_path']) + os.linesep)
 

--- a/ample/util/clusterize.py
+++ b/ample/util/clusterize.py
@@ -221,6 +221,7 @@ JOBID   USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
                 if log_file: sh += ['#$ -o {0}\n'.format(log_file)]
             if nproc and nproc > 1: sh += ['#$ -pe {0} {1}\n'.format(submit_pe_sge, nproc)]
             sh += ['\n']
+            sh += ['export PATH=${PATH}:${SGE_O_PATH}\n'] #Fix to address new version SGE PATH problem
         elif submit_qtype=="LSF":
             if nproc and submit_pe_lsf: sh += [submit_pe_lsf.format(nproc) + os.linesep]
             if job_time:


### PR DESCRIPTION
The new version of SGE on ccp4hpc01 doesn't pass the full environment through the "-V" option to queue jobs. This means that they don't get the full CCP4 environment. The fix is to add "SGE_O_PATH", which does contain the full environment, to the PATH variable. This should be ok with older versions of SGE so long as it doesn't exceed some limit on the PATH length.