### PR TITLE
Change SHELXE rebuild limits based on coiled_coil mode or command-line flag

### DIFF
--- a/ample/util/argparse_util.py
+++ b/ample/util/argparse_util.py
@@ -360,28 +360,29 @@ def add_mr_options(parser=None):
         metavar='True/False',
         help='True to use Buccaneer to rebuild the REFMAC-refined MR result.',
     )
-    mr_group.add_argument('-shelx_cycles', help='The number of shelx cycles to run when rebuilding.')
-    mr_group.add_argument('-shelxe_exe', metavar='path to shelxe executable', help='Path to the shelxe executable')
+    mr_group.add_argument('-shelx_cycles', help='The number of SHELXE cycles to run when rebuilding.')
+    mr_group.add_argument('-shelxe_exe', metavar='path to shelxe executable', help='Path to the SHELXE executable')
+    mr_group.add_argument('-shelxe_max_resolution', help='Maximum permitted resolution for rebuidling with SHELXE')
     mr_group.add_argument(
         '-shelxe_rebuild',
         action=BoolAction,
         nargs='?',
         metavar='True/False',
-        help='Rebuild shelxe traced pdb with buccaneer and arpwarp',
+        help='Rebuild SHELXE traced pdb with buccaneer and arpwarp',
     )
     mr_group.add_argument(
         '-shelxe_rebuild_arpwarp',
         action=BoolAction,
         nargs='?',
         metavar='True/False',
-        help='Rebuild shelxe traced pdb with arpwarp',
+        help='Rebuild SHELXE traced pdb with arpwarp',
     )
     mr_group.add_argument(
         '-shelxe_rebuild_buccaneer',
         action=BoolAction,
         nargs='?',
         metavar='True/False',
-        help='Rebuild shelxe traced pdb with buccaneer',
+        help='Rebuild SHELXE traced pdb with buccaneer',
     )
     mr_group.add_argument(
         '-use_scwrl',
@@ -390,7 +391,7 @@ def add_mr_options(parser=None):
         metavar='True/False',
         help='Remodel sidechains of the decoy models using Scwrl4',
     )
-    mr_group.add_argument('-use_shelxe', action=BoolAction, nargs='?', metavar='True/False', help='True to use shelxe')
+    mr_group.add_argument('-use_shelxe', action=BoolAction, nargs='?', metavar='True/False', help='True to use SHELXE')
     return parser
 
 

--- a/ample/util/argparse_util.py
+++ b/ample/util/argparse_util.py
@@ -362,7 +362,7 @@ def add_mr_options(parser=None):
     )
     mr_group.add_argument('-shelx_cycles', help='The number of SHELXE cycles to run when rebuilding.')
     mr_group.add_argument('-shelxe_exe', metavar='path to shelxe executable', help='Path to the SHELXE executable')
-    mr_group.add_argument('-shelxe_max_resolution', help='Maximum permitted resolution for rebuidling with SHELXE')
+    mr_group.add_argument('-shelxe_max_resolution', help='Maximum permitted resolution for rebuilding with SHELXE')
     mr_group.add_argument(
         '-shelxe_rebuild',
         action=BoolAction,

--- a/ample/util/mrbump_util.py
+++ b/ample/util/mrbump_util.py
@@ -28,6 +28,7 @@ TOP_KEEP = 3  # How many of the top shelxe/phaser results to keep for the gui
 MRBUMP_RUNTIME = 172800  # allow 48 hours for each mrbump job
 REBUILD_MAX_PERMITTED_RESOLUTION = 4.0
 SHELXE_MAX_PERMITTED_RESOLUTION = 3.0
+SHELXE_MAX_PERMITTED_RESOLUTION_CC = 3.5
 
 # Values to determine when job has succeeded - required at module level this may be set by AMPLE from
 # the command line

--- a/ample/util/options_processor.py
+++ b/ample/util/options_processor.py
@@ -407,13 +407,19 @@ def process_mr_options(optd):
         optd['refine_rebuild_arpwarp'] = False
         optd['refine_rebuild_buccaneer'] = False
 
+    if optd['shelxe_max_resolution'] < 0.0:
+        if optd['coiled_coil']:
+            optd['shelxe_max_resolution'] = mrbump_util.SHELXE_MAX_PERMITTED_RESOLUTION_CC
+        else:
+            optd['shelxe_max_resolution'] = mrbump_util.SHELXE_MAX_PERMITTED_RESOLUTION
+    
     # We use shelxe by default so if we can't find it we just warn and set use_shelxe to False
     if optd['use_shelxe']:
-        if optd['mtz_min_resolution'] > mrbump_util.SHELXE_MAX_PERMITTED_RESOLUTION:
+        if optd['mtz_min_resolution'] > optd['shelxe_max_resolution']:
             logger.warn(
                 "Disabling use of SHELXE as min resolution of %f is < accepted limit of %f",
                 optd['mtz_min_resolution'],
-                mrbump_util.SHELXE_MAX_PERMITTED_RESOLUTION,
+                optd['shelxe_max_resolution'],
             )
             optd['use_shelxe'] = False
             optd['shelxe_rebuild'] = False

--- a/ample/util/tests/test_options_processor.py
+++ b/ample/util/tests/test_options_processor.py
@@ -1,6 +1,7 @@
 """Tests for util.config_util"""
 
 import unittest
+import random
 
 from ample.util.config_util import AMPLEConfigOptions
 from ample.util import argparse_util
@@ -60,7 +61,7 @@ class Test(unittest.TestCase):
         options.populate(argso)
 
         options.d['shelxe_rebuild'] = True
-        limit = SHELXE_MAX_PERMITTED_RESOLUTION + ((SHELXE_MAX_PERMITTED_RESOLUTION_CC - SHELXE_MAX_PERMITTED_RESOLUTION) / 2)
+        limit = random.uniform(SHELXE_MAX_PERMITTED_RESOLUTION, SHELXE_MAX_PERMITTED_RESOLUTION_CC)
         options.d['mtz_min_resolution'] = limit
         options_processor.process_mr_options(options.d)
         
@@ -70,9 +71,9 @@ class Test(unittest.TestCase):
         
     def test_options_shelxe_resolution_cmd(self):
         """Check limit with coiled-coil mode turned on
+        Need to see if we can override and extend the original limit
         """
-        extra = (REBUILD_MAX_PERMITTED_RESOLUTION - SHELXE_MAX_PERMITTED_RESOLUTION_CC) / 2
-        limit = REBUILD_MAX_PERMITTED_RESOLUTION - extra
+        limit = random.uniform(SHELXE_MAX_PERMITTED_RESOLUTION_CC, REBUILD_MAX_PERMITTED_RESOLUTION)
         options = AMPLEConfigOptions()
         argso = argparse_util.process_command_line(args=['-mtz', 'foo',
                                                          '-fasta', 'bar',
@@ -82,7 +83,7 @@ class Test(unittest.TestCase):
         
         options.d['use_shelxe'] = True
         options.d['shelxe_rebuild'] = True
-        options.d['mtz_min_resolution'] = SHELXE_MAX_PERMITTED_RESOLUTION_CC + (extra / 2)
+        options.d['mtz_min_resolution'] = random.uniform(limit, REBUILD_MAX_PERMITTED_RESOLUTION)
         options_processor.process_mr_options(options.d)
         
         self.assertTrue(options.d['use_shelxe'])

--- a/ample/util/tests/test_options_processor.py
+++ b/ample/util/tests/test_options_processor.py
@@ -1,39 +1,90 @@
 """Tests for util.config_util"""
 
-import os
-import tempfile
 import unittest
 
 from ample.util.config_util import AMPLEConfigOptions
 from ample.util import argparse_util
 from ample.util import options_processor
+from ample.util.mrbump_util import REBUILD_MAX_PERMITTED_RESOLUTION
 from ample.util.mrbump_util import SHELXE_MAX_PERMITTED_RESOLUTION
+from ample.util.mrbump_util import SHELXE_MAX_PERMITTED_RESOLUTION_CC
 
 __author__ = "Jens Thomas"
 
 
 class Test(unittest.TestCase):
-    def test_process_mr_options(self):
-        """Make sure we handle resolution limits around SHELXE use properly
+
+    def test_options_shelxe_resolution_max(self):
+        """Make sure we turn off shelxe if resolution is outside limit
         """
         options = AMPLEConfigOptions()
-        argso = argparse_util.process_command_line(args=['-mtz', 'foo', '-fasta', 'bar'])
+        argso = argparse_util.process_command_line(args=['-mtz', 'foo',
+                                                         '-fasta', 'bar'])
         options.populate(argso)
 
-        # Make sure we turn off shelxe if resolution is outside limit
         self.assertTrue(options.d['use_shelxe'])  # default so should be true
         options.d['shelxe_rebuild'] = True
+
         # Set resolution below limit
         options.d['mtz_min_resolution'] = SHELXE_MAX_PERMITTED_RESOLUTION + 1
         options_processor.process_mr_options(options.d)
+
         self.assertFalse(options.d['use_shelxe'])
         self.assertFalse(options.d['shelxe_rebuild'])
 
-        # Check we don't accidently turn it off if above limit
-        options.d['use_shelxe'] = True
+
+    def test_options_shelxe_resolution_ok(self):
+        """Check we don't accidently turn it off if above limit
+        """
+        options = AMPLEConfigOptions()
+        argso = argparse_util.process_command_line(args=['-mtz', 'foo',
+                                                         '-fasta', 'bar'])
+        options.populate(argso)
+
+        self.assertTrue(options.d['use_shelxe'])  # default so should be true
         options.d['shelxe_rebuild'] = True
         options.d['mtz_min_resolution'] = SHELXE_MAX_PERMITTED_RESOLUTION - 1
         options_processor.process_mr_options(options.d)
+        
+        self.assertTrue(options.d['use_shelxe'])
+        self.assertTrue(options.d['shelxe_rebuild'])
+
+
+    def test_options_shelxe_resolution_cc(self):
+        """Check limit with coiled-coil mode turned on
+        """
+        options = AMPLEConfigOptions()
+        argso = argparse_util.process_command_line(args=['-mtz', 'foo',
+                                                         '-fasta', 'bar',
+                                                         '-coiled_coil', 'True'])
+        options.populate(argso)
+
+        options.d['shelxe_rebuild'] = True
+        limit = SHELXE_MAX_PERMITTED_RESOLUTION + ((SHELXE_MAX_PERMITTED_RESOLUTION_CC - SHELXE_MAX_PERMITTED_RESOLUTION) / 2)
+        options.d['mtz_min_resolution'] = limit
+        options_processor.process_mr_options(options.d)
+        
+        self.assertTrue(options.d['use_shelxe'])
+        self.assertTrue(options.d['shelxe_rebuild'])
+        
+        
+    def test_options_shelxe_resolution_cmd(self):
+        """Check limit with coiled-coil mode turned on
+        """
+        extra = (REBUILD_MAX_PERMITTED_RESOLUTION - SHELXE_MAX_PERMITTED_RESOLUTION_CC) / 2
+        limit = REBUILD_MAX_PERMITTED_RESOLUTION - extra
+        options = AMPLEConfigOptions()
+        argso = argparse_util.process_command_line(args=['-mtz', 'foo',
+                                                         '-fasta', 'bar',
+                                                         '-coiled_coil', 'True',
+                                                         '-shelxe_max_resolution', str(limit)])
+        options.populate(argso)
+        
+        options.d['use_shelxe'] = True
+        options.d['shelxe_rebuild'] = True
+        options.d['mtz_min_resolution'] = SHELXE_MAX_PERMITTED_RESOLUTION_CC + (extra / 2)
+        options_processor.process_mr_options(options.d)
+        
         self.assertTrue(options.d['use_shelxe'])
         self.assertTrue(options.d['shelxe_rebuild'])
 

--- a/include/ample.ini
+++ b/include/ample.ini
@@ -140,6 +140,7 @@ refine_rebuild_arpwarp     = False
 refine_rebuild_buccaneer   = False
 shelx_cycles               = 15
 shelxe_rebuild             = True
+shelxe_max_resolution      = -1.0
 shelxe_rebuild_arpwarp     = False
 shelxe_rebuild_buccaneer   = False
 SIGF                       = None


### PR DESCRIPTION
Set maximum allowed SHELXE rebuilt limit with the flag: -shelxe_max_resolution

If this isn't set we use the variables SHELXE_MAX_PERMITTED_RESOLUTION_CC or SHELXE_MAX_PERMITTED_RESOLUTION from mrbump_util depending on whether we are in coiled coil mode or not.