### PR TITLE
Let users choose the set of helical ensembles to be used

### DIFF
--- a/ample/main.py
+++ b/ample/main.py
@@ -255,13 +255,13 @@ class Ample(object):
             ensembler.import_ensembles(optd)
         elif optd['ideal_helices']:
             ample_util.ideal_helices(optd)
-            logger.info("*** Using ideal helices to solve structure ***")
+            logger.info("*** Attempting to solve the structure using ideal helices ***")
             logger.warning('If ideal helices do not solve the structure, you may want to use -helical_ensembles in '
                            'place of -ideal_helices. AMPLE will then use a new set of helical ensembles which has been '
                            'very successful on solving challenging cases!')
         elif optd['helical_ensembles']:
             ample_util.ideal_helices(optd)
-            logger.info("*** Using %s set of helical ensembles to solve structure ***" % optd['helical_ensembles_set'])
+            logger.info("*** Attempting to solve the structure using %s set of helical ensembles ***" % optd['helical_ensembles_set'])
         else:
             # Check we have some models to work with
             if not (optd['single_model_mode'] or optd['processed_models']):

--- a/ample/main.py
+++ b/ample/main.py
@@ -260,8 +260,8 @@ class Ample(object):
                            'place of -ideal_helices. AMPLE will then use a new set of helical ensembles which has been '
                            'very successful on solving challenging cases!')
         elif optd['helical_ensembles']:
-            ample_util.ideal_helices(optd, ensembles=True)
-            logger.info("*** Using helical ensembles to solve structure ***")
+            ample_util.ideal_helices(optd)
+            logger.info("*** Using %s set of helical ensembles to solve structure ***" % optd['helical_ensembles_set'])
         else:
             # Check we have some models to work with
             if not (optd['single_model_mode'] or optd['processed_models']):

--- a/ample/util/ample_util.py
+++ b/ample/util/ample_util.py
@@ -266,16 +266,13 @@ def filename_append(filename=None, astr=None, directory=None, separator="_"):
     return os.path.join(directory, name)
 
 
-def ideal_helices(optd, ensembles=False):
+def ideal_helices(optd):
     """Get some ideal helices
 
     Parameters
     ----------
     nresidues : int
        Number of residues to be used
-
-    ensembles : bool
-       If True then helical ensembles will be used instead of polyalanine ideal helices
 
     Returns
     -------
@@ -285,9 +282,16 @@ def ideal_helices(optd, ensembles=False):
     """
     nresidues = optd['fasta_length']
     include_dir = os.path.join(SHARE_DIR, 'include')
-    if not ensembles:
+    if not optd['helical_ensembles']:
         names = ['polyala_5', 'polyala_10', 'polyala_15', 'polyala_20', 'polyala_25', 'polyala_30', 'polyala_35',
                  'polyala_40']
+    elif optd['helical_ensembles_set'] == 'minimal':
+        names = ['ensemble_20_bfactor2_homogeneous', 'ensemble_20_bfactor3_homogeneous',
+                 'ensemble_15_bfactor2_homogeneous', 'ensemble_15_bfactor3_homogeneous',
+                 'ensemble_25_bfactor2_homogeneous', 'ensemble_25_bfactor3_homogeneous',
+                 'ensemble_30_bfactor2_homogeneous', 'ensemble_30_bfactor3_homogeneous',
+                 'ensemble_35_bfactor2_homogeneous', 'ensemble_35_bfactor3_homogeneous',
+                 'ensemble_40_bfactor2_homogeneous', 'ensemble_40_bfactor3_homogeneous']
     else:
         names = ['ensemble_20_bfactor2_homogeneous', 'ensemble_20_bfactor2_heterogeneous',
                  'ensemble_20_bfactor1_heterogeneous', 'ensemble_20_bfactor1_homogeneous',
@@ -295,34 +299,32 @@ def ideal_helices(optd, ensembles=False):
                  'ensemble_20_bfactor3_heterogeneous', 'ensemble_20_bfactor4_homogeneous',
                  'ensemble_15_bfactor2_heterogeneous', 'ensemble_15_bfactor2_homogeneous',
                  'ensemble_15_bfactor1_heterogeneous', 'ensemble_15_bfactor1_homogeneous',
-                 'ensemble_15_bfactor4_heterogeneous',
-                 'ensemble_15_bfactor3_heterogeneous', 'ensemble_15_bfactor4_homogeneous',
-                 'ensemble_15_bfactor3_homogeneous', 'ensemble_25_bfactor2_homogeneous',
-                 'ensemble_25_bfactor2_heterogeneous', 'ensemble_25_bfactor1_heterogeneous',
-                 'ensemble_25_bfactor1_homogeneous', 'ensemble_25_bfactor4_homogeneous',
-                 'ensemble_25_bfactor3_homogeneous', 'ensemble_25_bfactor4_heterogeneous',
-                 'ensemble_25_bfactor3_heterogeneous', 'ensemble_30_bfactor2_homogeneous',
-                 'ensemble_30_bfactor2_heterogeneous', 'ensemble_30_bfactor1_heterogeneous',
-                 'ensemble_30_bfactor1_homogeneous', 'ensemble_30_bfactor4_homogeneous',
-                 'ensemble_30_bfactor4_heterogeneous',
+                 'ensemble_15_bfactor4_heterogeneous', 'ensemble_15_bfactor3_heterogeneous',
+                 'ensemble_15_bfactor4_homogeneous', 'ensemble_15_bfactor3_homogeneous',
+                 'ensemble_25_bfactor2_homogeneous', 'ensemble_25_bfactor2_heterogeneous',
+                 'ensemble_25_bfactor1_heterogeneous', 'ensemble_25_bfactor1_homogeneous',
+                 'ensemble_25_bfactor4_homogeneous', 'ensemble_25_bfactor3_homogeneous',
+                 'ensemble_25_bfactor4_heterogeneous', 'ensemble_25_bfactor3_heterogeneous',
+                 'ensemble_30_bfactor2_homogeneous', 'ensemble_30_bfactor2_heterogeneous',
+                 'ensemble_30_bfactor1_heterogeneous', 'ensemble_30_bfactor1_homogeneous',
+                 'ensemble_30_bfactor4_homogeneous', 'ensemble_30_bfactor4_heterogeneous',
                  'ensemble_30_bfactor3_heterogeneous', 'ensemble_30_bfactor3_homogeneous',
                  'ensemble_35_bfactor2_homogeneous', 'ensemble_35_bfactor2_heterogeneous',
                  'ensemble_35_bfactor1_heterogeneous', 'ensemble_35_bfactor1_homogeneous',
-                 'ensemble_35_bfactor4_heterogeneous',
-                 'ensemble_35_bfactor4_homogeneous', 'ensemble_35_bfactor3_homogeneous',
-                 'ensemble_35_bfactor3_heterogeneous', 'ensemble_40_bfactor2_homogeneous',
-                 'ensemble_40_bfactor2_heterogeneous', 'ensemble_40_bfactor1_heterogeneous',
-                 'ensemble_40_bfactor1_homogeneous', 'ensemble_40_bfactor4_heterogeneous',
-                 'ensemble_40_bfactor3_heterogeneous', 'ensemble_40_bfactor4_homogeneous',
-                 'ensemble_40_bfactor3_homogeneous', 'ensemble_10_bfactor2_heterogeneous',
-                 'ensemble_10_bfactor2_homogeneous', 'ensemble_10_bfactor1_heterogeneous',
-                 'ensemble_10_bfactor1_homogeneous', 'ensemble_10_bfactor3_homogeneous',
-                 'ensemble_10_bfactor4_homogeneous', 'ensemble_10_bfactor3_heterogeneous',
-                 'ensemble_10_bfactor4_heterogeneous', 'ensemble_5_bfactor2_heterogeneous',
-                 'ensemble_5_bfactor2_homogeneous', 'ensemble_5_bfactor1_heterogeneous',
-                 'ensemble_5_bfactor1_homogeneous', 'ensemble_5_bfactor4_homogeneous',
-                 'ensemble_5_bfactor3_heterogeneous', 'ensemble_5_bfactor3_homogeneous',
-                 'ensemble_5_bfactor4_heterogeneous']
+                 'ensemble_35_bfactor4_heterogeneous', 'ensemble_35_bfactor4_homogeneous',
+                 'ensemble_35_bfactor3_homogeneous', 'ensemble_35_bfactor3_heterogeneous',
+                 'ensemble_40_bfactor2_homogeneous', 'ensemble_40_bfactor2_heterogeneous',
+                 'ensemble_40_bfactor1_heterogeneous', 'ensemble_40_bfactor1_homogeneous',
+                 'ensemble_40_bfactor4_heterogeneous', 'ensemble_40_bfactor3_heterogeneous',
+                 'ensemble_40_bfactor4_homogeneous', 'ensemble_40_bfactor3_homogeneous',
+                 'ensemble_10_bfactor2_heterogeneous', 'ensemble_10_bfactor2_homogeneous',
+                 'ensemble_10_bfactor1_heterogeneous', 'ensemble_10_bfactor1_homogeneous',
+                 'ensemble_10_bfactor3_homogeneous', 'ensemble_10_bfactor4_homogeneous',
+                 'ensemble_10_bfactor3_heterogeneous', 'ensemble_10_bfactor4_heterogeneous',
+                 'ensemble_5_bfactor2_heterogeneous', 'ensemble_5_bfactor2_homogeneous',
+                 'ensemble_5_bfactor1_heterogeneous', 'ensemble_5_bfactor1_homogeneous',
+                 'ensemble_5_bfactor4_homogeneous', 'ensemble_5_bfactor3_heterogeneous',
+                 'ensemble_5_bfactor3_homogeneous', 'ensemble_5_bfactor4_heterogeneous']
 
     ensemble_options = {}
     ensembles_data = []

--- a/ample/util/argparse_util.py
+++ b/ample/util/argparse_util.py
@@ -168,6 +168,8 @@ def add_general_options(parser=None):
         metavar='True/False',
         help='Use helical ensembles to solve structure (64 ensembles)',
     )
+    parser.add_argument('-helical_ensembles_set', choices=['full', 'minimal'], nargs='?', default='minimal',
+                        help='Choose the set of helical ensembles to be used: full - 64 ensembles,  minimal - 12 ensembles')
 
     parser.add_argument(
         '-improve_template', metavar='improve_template', help='Path to a template to improve - NMR, homolog'

--- a/ample/util/argparse_util.py
+++ b/ample/util/argparse_util.py
@@ -159,14 +159,14 @@ def add_general_options(parser=None):
         action=BoolAction,
         nargs='?',
         metavar='True/False',
-        help='Use ideal polyalanine helices to solve structure (8 helices: from 5-40 residues)',
+        help='Attempt to solve the structure using ideal polyalanine helices (8 helices: from 5-40 residues)',
     )
     parser.add_argument(
         '-helical_ensembles',
         action=BoolAction,
         nargs='?',
         metavar='True/False',
-        help='Use helical ensembles to solve structure (64 ensembles)',
+        help='Attempt to solve the structure using helical ensembles (minimal set of 12 ensembles used by default)',
     )
     parser.add_argument('-helical_ensembles_set', choices=['full', 'minimal'], nargs='?', default='minimal',
                         help='Choose the set of helical ensembles to be used: full - 64 ensembles,  minimal - 12 ensembles')


### PR DESCRIPTION
Added new argument `-helical_ensembles_set` that lets users choose which set of ensembles should be used: the full set of 64 ensembles or the minimal set of 12 ensembles instead.