### PR TITLE
Update online documentation

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,2 +1,3 @@
 sphinx-argparse
 sphinx_bootstrap_theme ==0.5.3
+pyjob ==0.3

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -13,15 +13,18 @@ Currently an online websever to run AMPLE is available through CCP4 online:
    </div>
    </br>
 
-AMPLE is also available through CCP4-Cloud:
+.. note::
+    AMPLE will be made available through CCP4 cloud too before long
 
-.. raw:: html
+..
+  AMPLE is also available through CCP4-Cloud:
 
-   <br>
-   <div>
-       <a target="_blank" href="https://cloud.ccp4.ac.uk/" class="btn btn-primary btn-lg">Go to CCP4 Cloud</a>
-   </div>
-   </br>
+    .. raw:: html
 
-These make some of the most popular protocols available in an easy-to-use form but greater flexibility is accessible through the CCP4 GUIs or the command line.
+       <br>
+       <div>
+           <a target="_blank" href="http://ccp4serv6.rc-harwell.ac.uk/jscofe/" class="btn btn-primary btn-lg">Go to CCP4 Cloud</a>
+       </div>
+       </br>
 
+    These make some of the most popular protocols available in an easy-to-use form but greater flexibility is accessible through the CCP4 GUIs or the command line.

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -13,19 +13,15 @@ Currently an online websever to run AMPLE is available through CCP4 online:
    </div>
    </br>
 
-.. note::
-    AMPLE will be made available through CCP4 cloud too before long
+AMPLE is also available through CCP4-Cloud:
 
-..
-  AMPLE is also available through CCP4-Cloud:
+.. raw:: html
 
-    .. raw:: html
+   <br>
+   <div>
+       <a target="_blank" href="https://cloud.ccp4.ac.uk/" class="btn btn-primary btn-lg">Go to CCP4 Cloud</a>
+   </div>
+   </br>
 
-       <br>
-       <div>
-           <a target="_blank" href="http://ccp4serv6.rc-harwell.ac.uk/jscofe/" class="btn btn-primary btn-lg">Go to CCP4 Cloud</a>
-       </div>
-       </br>
-
-    These make some of the most popular protocols available in an easy-to-use form but greater flexibility is accessible through the CCP4 GUIs or the command line.
+These make some of the most popular protocols available in an easy-to-use form but greater flexibility is accessible through the CCP4 GUIs or the command line.
 

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -9,7 +9,7 @@ Currently an online websever to run AMPLE is available through CCP4 online:
 
    <br>
    <div>
-       <a target="_blank" href="https://www.ccp4.ac.uk/ccp4online/" class="btn btn-primary btn-lg">Go to CCP4 Online Server</a>
+       <a target="_blank" href="https://ccp4online.ccp4.ac.uk/ccp4online/" class="btn btn-primary btn-lg">Go to CCP4 Online Server</a>
    </div>
    </br>
 

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -28,3 +28,4 @@ Currently an online websever to run AMPLE is available through CCP4 online:
        </br>
 
     These make some of the most popular protocols available in an easy-to-use form but greater flexibility is accessible through the CCP4 GUIs or the command line.
+


### PR DESCRIPTION
Minor changes to the documentation, started working on issue #82 and thought I could add a few things since I was already on it:

- I think this should close #82 . I believe the problem was that when AMPLE was updated to use pyjob (PR #79) we forgot to add `pyjob` into `docs-requirements.txt`. The compiler was unable to find `pyjob.factory` when reading `ample.util.argparse_util` as suggested in the logs:
```
api/options/general.rst:6: WARNING: Failed to import "add_general_options" from "ample.util.argparse_util".
No module named pyjob.factory
```
- CCP4 online has moved to a different URL and the button was no longer working, so I updated it.
- AMPLE is already included in CCP4 cloud (though only ab initio modelling is currently available), so I though we could add a button in the docs as well.